### PR TITLE
Migrate everything to match upcoming Detox changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 ## Description
 
-`detox-puppeteer` is a custom driver for [detox](https://github.com/wix/Detox/) that runs e2e tests for web apps with [puppeteer](https://github.com/puppeteer/puppeteer/) behind the scenes. `detox-puppeteer` may be a good fit for you if you already use detox for testing your android + ios react-native apps and have a web version as well.
+`detox-puppeteer` is a custom driver for [Detox](https://github.com/wix/Detox/) that runs e2e tests for web apps with [Puppeteer](https://github.com/puppeteer/puppeteer/) behind the scenes. `detox-puppeteer` may be a good fit for you if you already use detox for testing your android + ios react-native apps and have a web version as well.
 
 ## Getting started
 
-This plugin requires detox >= 17.3.0.
+**This plugin requires Detox ≥ `19.0.0`.**
 
-1. yarn add --dev detox-puppeteer
+> For Detox v18 and v17, use detox-puppeteer `v3.x.x`.
+
+
+
+1. Run `yarn add --dev detox-puppeteer`
 1. In `package.json` add a new configuration for `detox-puppeteer`
 
 #### New Detox configuration format

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "build/PuppeteerDriver.js",
   "private": false,
   "scripts": {
-    "test": "detox test --configuration simple"
+    "build": "tsc",
+    "test": "tsc && detox test --configuration simple"
   },
   "dependencies": {
     "lodash": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.8.4",
-    "@types/jest": "^25.0.2",
+    "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.149",
     "@types/node": "^13.7.0",
-    "detox": "^18.0.0",
-    "jest": "^25.2.5",
+    "detox": "next",
+    "jest": "^27.3.1",
     "prettier": "^1.19.0",
     "typescript": "4.2.4"
   },

--- a/src/PuppeteerDriver.ts
+++ b/src/PuppeteerDriver.ts
@@ -131,16 +131,17 @@ class PuppeteerTestee {
   sessionId: string;
   isDetox17OrBefore: boolean;
 
-  constructor(config) {
+  constructor(deps) {
     // console.log('PuppeteerTestee.constructor', config);
-    const isDetox17OrBefore = !!config.client.configuration;
+    const { client } = deps;
+    const isDetox17OrBefore = !!client.configuration;
     this.isDetox17OrBefore = isDetox17OrBefore;
     if (isDetox17OrBefore) {
-      this.sessionId = config.client.configuration.sessionId;
-      this.client = new Client(config.client.configuration);
+      this.sessionId = client.configuration.sessionId;
+      this.client = new Client(client.configuration);
     } else {
-      this.sessionId = config.client._sessionId;
-      this.client = new Client({ sessionId: this.sessionId, server: config.client._serverUrl });
+      this.sessionId = client._sessionId;
+      this.client = new Client({ sessionId: this.sessionId, server: client._serverUrl });
       this.client.ws = this.client._asyncWebSocket;
     }
     this.inflightRequests = {};
@@ -794,14 +795,17 @@ class PuppeteerTestee {
   }
 }
 
-class PuppeteerDriver extends DeviceDriverBase {
-  constructor(config) {
-    super(config);
-    debug('constructor', config);
-
-    this.testee = new PuppeteerTestee(config);
+class PuppeteerEnvironmentValidator {
+  validate() {
+    // const detoxFrameworkPath = await environment.getFrameworkPath();
+    // if (!fs.existsSync(detoxFrameworkPath)) {
+    //   throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful.
+    //   To attempt a fix try running 'detox clean-framework-cache && detox build-framework-cache'`);
+    // }
   }
+}
 
+class PuppeteerArtifactPluginsProvider {
   declareArtifactPlugins() {
     debug('declareArtifactPlugins');
     return {
@@ -810,6 +814,59 @@ class PuppeteerDriver extends DeviceDriverBase {
       screenshot: (api) => new PuppeteerScreenshotPlugin({ api, driver: this }),
       video: (api) => new PuppeteerRecordVideoPlugin({ api, driver: this }),
     };
+  }
+}
+
+class PuppeteerAllocCookie {
+  testee: PuppeteerTestee;
+  id: any;
+
+  constructor(testee) {
+    this.testee = testee;
+    this.id = '';
+  }
+}
+
+class PuppeteerDeviceAllocation {
+  private readonly testee: PuppeteerTestee;
+
+  constructor(deps) {
+    this.testee = new PuppeteerTestee(deps);
+  }
+
+  async allocate(deviceConfig) {
+    debug('PuppeteerAllocation.allocate', deviceConfig.device);
+    return new PuppeteerAllocCookie(this.testee);
+  }
+
+  async free(deviceCookie: PuppeteerAllocCookie, { shutdown }) {
+    const { id } = deviceCookie;
+
+    if (shutdown) {
+      await this.emitter.emit('beforeShutdownDevice', { deviceId: id });
+      await this.emitter.emit('shutdownDevice', { deviceId: id });
+    }
+  }
+}
+
+class PuppeteerRuntimeDriver extends DeviceDriverBase {
+  private readonly deviceId: any;
+  private readonly testee: PuppeteerTestee;
+
+  constructor(cookie: PuppeteerAllocCookie, deps) {
+    super(deps);
+    debug('constructor');
+
+    this.testee = cookie.testee;
+    this.deviceId = cookie.id;
+  }
+
+  getExternalId() {
+    return '';
+  }
+
+  getDeviceName() {
+    return 'puppeteer';
   }
 
   createPayloadFile(notification) {
@@ -833,11 +890,11 @@ class PuppeteerDriver extends DeviceDriverBase {
     enableSynchronization = false;
   }
 
-  async shake(deviceId) {
+  async shake() {
     return await this.client.shake();
   }
 
-  async setOrientation(deviceId, orientation) {
+  async setOrientation(orientation) {
     const viewport = page!.viewport()!;
     const isLandscape = orientation === 'landscape';
     const largerDimension = Math.max(viewport.width, viewport.height);
@@ -854,15 +911,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     return 'web';
   }
 
-  async prepare() {
-    // const detoxFrameworkPath = await environment.getFrameworkPath();
-    // if (!fs.existsSync(detoxFrameworkPath)) {
-    //   throw new Error(`${detoxFrameworkPath} could not be found, this means either you changed a version of Xcode or Detox postinstall script was unsuccessful.
-    //   To attempt a fix try running 'detox clean-framework-cache && detox build-framework-cache'`);
-    // }
-  }
-
-  async recordVideo(deviceId) {
+  async recordVideo() {
     debug('recordVideo', { page: !!page });
     if (!page) {
       recordVideo = true;
@@ -875,7 +924,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     isRecording = true;
   }
 
-  async stopVideo(deviceId) {
+  async stopVideo() {
     debug('stopVideo', { pendingExport });
     if (pendingExport) {
       const value = pendingExport;
@@ -907,8 +956,8 @@ class PuppeteerDriver extends DeviceDriverBase {
     return pendingExport;
   }
 
-  async cleanup(deviceId, bundleId) {
-    debug('TODO cleanup', { deviceId, bundleId, browser: !!browser });
+  async cleanup(bundleId) {
+    debug('TODO cleanup', { bundleId, browser: !!browser });
     // await sleep(100000);
 
     if (browser) {
@@ -920,12 +969,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     // stopSync is safe to call even if startSync() wasn't
     xvfb.stopSync();
 
-    await super.cleanup(deviceId, bundleId);
-  }
-
-  async acquireFreeDevice(deviceQuery, deviceConfig) {
-    debug('PuppeteerDriver.acquireFreeDevice', deviceQuery, deviceConfig);
-    return '';
+    await super.cleanup(bundleId);
   }
 
   async getBundleIdFromBinary(appPath) {
@@ -933,13 +977,13 @@ class PuppeteerDriver extends DeviceDriverBase {
     return appPath;
   }
 
-  async installApp(deviceId, binaryPath) {
-    debug('installApp', { deviceId, binaryPath });
+  async installApp(binaryPath) {
+    debug('installApp', { binaryPath });
   }
 
-  async uninstallApp(deviceId, bundleId) {
-    debug('uninstallApp', { deviceId, bundleId });
-    await this.emitter.emit('beforeUninstallApp', { deviceId, bundleId });
+  async uninstallApp(bundleId) {
+    debug('uninstallApp', { bundleId });
+    await this.emitter.emit('beforeUninstallApp', { deviceId: this.deviceId, bundleId });
     if (browser) {
       await browser.close();
       browser = null;
@@ -947,15 +991,16 @@ class PuppeteerDriver extends DeviceDriverBase {
     }
   }
 
-  async launchApp(deviceId, bundleId, launchArgs, languageAndLocale) {
+  async launchApp(bundleId, launchArgs, languageAndLocale) {
     debug('launchApp', {
       browser: !!browser,
-      deviceId,
       bundleId,
       launchArgs,
       languageAndLocale,
       config: this.deviceConfig,
     });
+    const { deviceId } = this;
+
     await this.emitter.emit('beforeLaunchApp', {
       bundleId,
       deviceId,
@@ -1003,11 +1048,11 @@ class PuppeteerDriver extends DeviceDriverBase {
       page = (await browser.pages())[0];
       await page!.goto(url, { waitUntil: NETWORKIDLE });
       if (recordVideo) {
-        await this.recordVideo(deviceId);
+        await this.recordVideo();
       }
     }
 
-    await this._applyPermissions(deviceId, bundleId);
+    await this._applyPermissions();
 
     // const pid = await this.applesimutils.launch(deviceId, bundleId, launchArgs, languageAndLocale);
     const pid = 'PID';
@@ -1029,43 +1074,37 @@ class PuppeteerDriver extends DeviceDriverBase {
     return this._getDeviceOption('defaultViewport', { width: 1280, height: 720 });
   }
 
-  async terminate(deviceId, bundleId) {
-    debug('terminate', { deviceId, bundleId });
+  async terminate(bundleId) {
+    debug('terminate', { bundleId });
     // If we're in the middle of recording, signal to the next launch that we should start
     // in a recording state
     if (isRecording) {
       recordVideo = true;
     }
-    await this.stopVideo(deviceId);
-    await this.emitter.emit('beforeTerminateApp', { deviceId, bundleId });
+    await this.stopVideo();
+    await this.emitter.emit('beforeTerminateApp', { deviceId: this.deviceId, bundleId });
     if (browser) {
       await browser.close();
       browser = null;
       page = null;
     }
     // await this.applesimutils.terminate(deviceId, bundleId);
-    await this.emitter.emit('terminateApp', { deviceId, bundleId });
+    await this.emitter.emit('terminateApp', { deviceId: this.deviceId, bundleId });
   }
 
-  async sendToHome(deviceId) {
+  async sendToHome() {
     await page!.goto('https://google.com');
   }
 
-  async shutdown(deviceId) {
-    await this.emitter.emit('beforeShutdownDevice', { deviceId });
-    await this.applesimutils.shutdown(deviceId);
-    await this.emitter.emit('shutdownDevice', { deviceId });
-  }
-
-  async setLocation(deviceId, latitude, longitude) {
+  async setLocation(latitude, longitude) {
     await page!.setGeolocation({
       latitude: Number.parseFloat(latitude),
       longitude: Number.parseFloat(longitude),
     });
   }
 
-  async setPermissions(deviceId, bundleId, permissions: { [key: string]: string }) {
-    debug('setPermissions', { deviceId, bundleId, permissions });
+  async setPermissions(bundleId, permissions: { [key: string]: string }) {
+    debug('setPermissions', { bundleId, permissions });
     const PERMISSIONS_LOOKUP = {
       // calendar: '',
       camera: 'camera',
@@ -1093,7 +1132,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     this.requestedPermissions = requestedPermissions;
   }
 
-  async _applyPermissions(deviceId: string, bundleId: string) {
+  async _applyPermissions() {
     if (browser && this.requestedPermissions) {
       const context = browser.defaultBrowserContext();
       await context.clearPermissionOverrides();
@@ -1104,15 +1143,11 @@ class PuppeteerDriver extends DeviceDriverBase {
     }
   }
 
-  async clearKeychain(deviceId) {
-    await this.applesimutils.clearKeychain(deviceId);
+  async clearKeychain() {
   }
 
-  async resetContentAndSettings(deviceId) {
+  async resetContentAndSettings() {
     debug('TODO resetContentAndSettings');
-    // await this.shutdown(deviceId);
-    // await this.applesimutils.resetContentAndSettings(deviceId);
-    // await this._boot(deviceId);
   }
 
   validateDeviceConfig(deviceConfig) {
@@ -1123,8 +1158,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     }
   }
 
-  getLogsPaths(deviceId) {
-    return this.applesimutils.getLogsPaths(deviceId);
+  getLogsPaths() {
   }
 
   async waitForBackground() {
@@ -1133,7 +1167,7 @@ class PuppeteerDriver extends DeviceDriverBase {
     return Promise.resolve('');
   }
 
-  async takeScreenshot(udid, screenshotName) {
+  async takeScreenshot(screenshotName) {
     const tempPath = await temporaryPath.for.png();
     await page!.screenshot({ path: tempPath });
 
@@ -1146,12 +1180,10 @@ class PuppeteerDriver extends DeviceDriverBase {
     return tempPath;
   }
 
-  async setStatusBar(deviceId, flags) {
-    // await this.applesimutils.statusBarOverride(deviceId, flags);
+  async setStatusBar(flags) {
   }
 
-  async resetStatusBar(deviceId) {
-    // await this.applesimutils.statusBarReset(deviceId);
+  async resetStatusBar() {
   }
 
   async waitUntilReady() {
@@ -1172,6 +1204,9 @@ class PuppeteerDriver extends DeviceDriverBase {
 }
 
 export = {
-  DriverClass: PuppeteerDriver,
+  EnvironmentValidatorClass: PuppeteerEnvironmentValidator,
+  ArtifactPluginsProviderClass: PuppeteerArtifactPluginsProvider,
+  DeviceAllocationDriverClass: PuppeteerDeviceAllocation,
+  RuntimeDriverClass: PuppeteerRuntimeDriver,
   ExpectClass: WebExpect,
 };

--- a/src/PuppeteerDriver.ts
+++ b/src/PuppeteerDriver.ts
@@ -862,7 +862,7 @@ class PuppeteerRuntimeDriver extends DeviceDriverBase {
   }
 
   getExternalId() {
-    return '';
+    return this.deviceId;
   }
 
   getDeviceName() {

--- a/src/PuppeteerDriver.ts
+++ b/src/PuppeteerDriver.ts
@@ -5,7 +5,7 @@ const os = require('os');
 const Xvfb = require('xvfb');
 
 const log = require('detox/src/utils/logger').child({ __filename });
-const DeviceDriverBase = require('detox/src/devices/drivers/DeviceDriverBase');
+const DeviceDriverBase = require('detox/src/devices/runtime/drivers/DeviceDriverBase');
 const temporaryPath = require('detox/src/artifacts/utils/temporaryPath');
 const Client = require('detox/src/client/Client');
 
@@ -829,9 +829,11 @@ class PuppeteerAllocCookie {
 
 class PuppeteerDeviceAllocation {
   private readonly testee: PuppeteerTestee;
+  private readonly emitter: any;
 
   constructor(deps) {
     this.testee = new PuppeteerTestee(deps);
+    this.emitter = deps.eventEmitter;
   }
 
   async allocate(deviceConfig) {
@@ -853,7 +855,7 @@ class PuppeteerRuntimeDriver extends DeviceDriverBase {
   private readonly deviceId: any;
   private readonly testee: PuppeteerTestee;
 
-  constructor(cookie: PuppeteerAllocCookie, deps) {
+  constructor(deps: any, cookie: PuppeteerAllocCookie) {
     super(deps);
     debug('constructor');
 

--- a/src/PuppeteerRecordVideoPlugin.ts
+++ b/src/PuppeteerRecordVideoPlugin.ts
@@ -12,16 +12,15 @@ class PuppeteerRecordVideoPlugin extends VideoArtifactPlugin {
   }
 
   createTestRecording() {
-    const { context } = this;
     let temporaryFilePath;
 
     return new Artifact({
       name: 'PuppeteerVideoRecording',
       start: async () => {
-        await this.driver.recordVideo(context.deviceId);
+        await this.driver.recordVideo();
       },
       stop: async () => {
-        temporaryFilePath = await this.driver.stopVideo(context.deviceId);
+        temporaryFilePath = await this.driver.stopVideo();
       },
       save: async (artifactPath) => {
         await FileArtifact.moveTemporaryFile(log, temporaryFilePath, artifactPath);

--- a/src/PuppeteerScreenshotPlugin.ts
+++ b/src/PuppeteerScreenshotPlugin.ts
@@ -10,14 +10,14 @@ class PuppeteerScreenshotPlugin extends ScreenshotArtifactPlugin {
   }
 
   createTestArtifact() {
-    const { driver, context } = this;
+    const { driver } = this;
 
     return new FileArtifact({
       name: 'PuppeteerScreenshot',
 
       async start() {
         this.temporaryPath = temporaryPath.for.png();
-        await driver.takeScreenshot(context.deviceId, this.temporaryPath);
+        await driver.takeScreenshot(this.temporaryPath);
       },
     });
   }


### PR DESCRIPTION
Fixes #12. Here's the change summary:

The driver is no longer a monolith singleton. Instead, it's main concern is now to handle *"runtime"* (in-test) operations, having all other concerns broken down into several other classes:

1. Global environment validations previously piggybacked into `driver.preare()` can now be explicitly (yet optionally) performed in a dedicated class, under a `validate()` method (see `PuppeteerEnvironmentValidator.validate()`).
2. `driver.declareArtifactPlugins()` can be (optionally) done in a dedicated class (see `PuppeteerArtifactPluginsProvider.declareArtifactPlugins()`.
3. Albeit not very useful in `detox-puppeteer`, specifically -- `driver.acquireFreeDevice()` is no longer a thing. Instead, a new class is used, quite equivalently (see `PuppeteerDeviceAllocation.allocate()`). Similarly, `driver.shutdown` should be handled by class' `PuppeteerDeviceAllocation.free()`).
4. Depending on the needs, the `deviceId` can now be a direct property of the runtime driver. Hence, **the device ID no longer gets specified in each and every method the class holds, as its first parameter**. This is not reflected by the code of puppeteer, specifically.

All of the aforementioned classes are now exported explicitly, alongside the runtime driver.

**Allocation/Deallocation**

Device allocation has become a 1st-class citizen, with its own dedicate class and flow. Largely, the flow is:
1. Allocate a device through the dedicated allocator class. The result should be the allocator returning a _cookie_ object which should contain any data (e.g. ID's) that can help specify which exact device the test execution is associated with. For example, internally, Detox uses it for holding the ADB name of an Android device/emulator - for the Android case, and the global MacOS UDID for simulators.
2. From there-on-in, the cookie is propagated to the other classes (namely, deallocation and the runtime driver) in their constructor.
